### PR TITLE
sqb: allow p/entity to be an atom

### DIFF
--- a/src/walkable/sql_query_builder.cljc
+++ b/src/walkable/sql_query_builder.cljc
@@ -303,8 +303,9 @@
                           (process-query
                             (-> env
                               (assoc :ast join-child)
-                              (assoc-in [(get env ::p/entity-key) source-column]
-                                (get e source-column)))))
+                              (as-> env
+                                (update env (get env ::p/entity-key)
+                                  #(assoc (p/maybe-atom %) source-column (get e source-column)))))))
 
                         query-strings (map #(emitter/->query-string (:query-string-input %)) query-string-inputs)
                         all-params    (map :query-params query-string-inputs)
@@ -414,8 +415,9 @@
                             (process-query
                               (-> env
                                 (assoc :ast join-child)
-                                (assoc-in [(get env ::p/entity-key) source-column]
-                                  (get e source-column)))))
+                                (as-> env
+                                  (update env (get env ::p/entity-key)
+                                    #(assoc (p/maybe-atom %) source-column (get e source-column)))))))
 
                           query-strings (map #(emitter/->query-string (:query-string-input %)) query-string-inputs)
                           all-params    (map :query-params query-string-inputs)


### PR DESCRIPTION
In Pathom 2.2, entity is generally forced to be an atom. This wraps
any update to the entity in a call that derefs the value if it is an
atom, and returns it as-is otherwise.